### PR TITLE
Real life feedback

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -1,7 +1,8 @@
 Changelog
 ---------
 
-0.1.0 released <in development>
+0.1.1 released <in development>
 ==========================
 
- - ?
+ - Made SheetImporter easier to construct dynamically at runtime
+ - Added parsers for lists, mappings, and nullable fields


### PR DESCRIPTION
Two things from a real-life scenario I just encountered:

  - [x] Support easy run-time generation of `SheetImporter`s. Basically, complex parsers may need info from the database, so you can't construct the sheet statically as a class [easily].\* This change is actually the best of both worlds, since it will allow you to define your values on the class *or* through the constructor. If you don't want to support values in the constructor, then a subclass with no constructor arguments will do the trick.
  - [x] Add parsers for list-like data. I have a column that is a comma-separated list of fields.

\* Yes, you can create a class factory, but seriously, who wants a *class* *factory* just to get run-time dynamic code? Metaprogramming squares complexity, so I try to avoid it.
